### PR TITLE
Specify default working dir for ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./java
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8


### PR DESCRIPTION
Actions specified in CI state don't apply at top level directory, but rather at the java folder.

Signed-off-by: Ankit Shah <unckit@amulz.com>