### PR TITLE
Bump TestNG to 7.7.0 due to high severity security issue

### DIFF
--- a/java/object-extensibility/pom.xml
+++ b/java/object-extensibility/pom.xml
@@ -34,7 +34,7 @@
     <spring-amqp.version>2.3.11</spring-amqp.version>
     <spring-oxm.version>3.2.4.RELEASE</spring-oxm.version>
     <spring-rabbit.version>1.5.5.RELEASE</spring-rabbit.version>
-    <testng.version>6.8.1</testng.version>
+    <testng.version>7.7.0</testng.version>
     <spring-test.version>3.1.1.RELEASE</spring-test.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
Signed-off-by: abarreiro <abarreiro@vmware.com>